### PR TITLE
Add back button on proof page

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -16,6 +16,10 @@ const Index = () => {
     setCurrentPage('services');
   };
 
+  const handleBackHome = () => {
+    setCurrentPage('home');
+  };
+
   return (
     <div className="relative">
       <CursorGlow />
@@ -29,7 +33,7 @@ const Index = () => {
       )}
       
       {currentPage === 'services' && (
-        <Services />
+        <Services onBackHome={handleBackHome} />
       )}
     </div>
   );

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -4,6 +4,10 @@ import TestimonialCard from '@/components/TestimonialCard';
 import TestimonialCarousel from '@/components/TestimonialCarousel';
 import { Button } from '@/components/ui/button';
 
+interface ServicesProps {
+  onBackHome?: () => void;
+}
+
 const testimonialData = [
   {
     name: "TechGamer99",
@@ -31,13 +35,22 @@ const testimonialData = [
   }
 ];
 
-const Services = () => {
+const Services = ({ onBackHome }: ServicesProps) => {
   const handleContactUs = () => {
     window.open('mailto:contact@wammysagency.com', '_blank');
   };
 
   return (
-    <div className="min-h-screen bg-black text-white">
+    <div className="min-h-screen bg-black text-white relative">
+      {onBackHome && (
+        <Button
+          variant="link"
+          onClick={onBackHome}
+          className="absolute left-4 top-4 text-white"
+        >
+          Back to home
+        </Button>
+      )}
       {/* Header Section */}
       <div className="container mx-auto px-6 py-16">
         <div className="text-center mb-16">


### PR DESCRIPTION
## Summary
- add optional prop `onBackHome` to `Services`
- show a "Back to home" button at the top left of Services
- update `Index` to pass a callback that returns to the Home screen

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68409d75a51c833395db146d4506101a